### PR TITLE
Gr 138

### DIFF
--- a/report_overrepresented_sequences.py
+++ b/report_overrepresented_sequences.py
@@ -33,26 +33,26 @@ def main(argv):
       sys.exit()
 
    # Print out header of csv file
-   header = ",".join(['Project', 'Library', 'Run', 'Lane', 'Barcode', 'Sequence', 'Percentage'])
+   header = "\t".join(['Project', 'Library', 'Run', 'Lane', 'Barcode', 'Sequence', 'Percentage'])
    print(header)
 
    #open the file provenance report
-   with gzip.open(sw_filename) as tsv:
+   with open(sw_filename) as tsv:
        #parse the report into a map
       for line in csv.DictReader(tsv, delimiter="\t"):
          annos=None
 	 #find the FastQ files and calculates their adapter contamination numbers
          if 'chemical/seq-na-fastq-gzip' in line['File Meta-Type']:
-             firstbit=",".join([ line['Study Title'], line['Sample Name'], line['Sequencer Run Name'], line['Lane Number'], line['IUS Tag'] ])
+             firstbit="\t".join([ line['Study Title'], line['Sample Name'], line['Sequencer Run Name'], line['Lane Number'], line['IUS Tag'] ])
 
              # Get Trimmed reads percentage
              filePath = line['File Path'];
              m1 = re.match(".*?_(R[1|2])_.*", os.path.basename(filePath))
 
              if m1 is not None:
-                 firstbit = ",".join([firstbit, m1.group(1)])
+                 firstbit = "\t".join([firstbit, m1.group(1)])
              else:
-                 firstbit = firstbit + ","
+                 firstbit = firstbit + "\t"
 
              try:
                  p1 = subprocess.Popen(["zcat", filePath], stdout=subprocess.PIPE)
@@ -75,7 +75,7 @@ def main(argv):
              p2.stdout.close()
              m = re.findall('Trimmed\sreads.+\(\s+\d+\.\d+%\)', p3)
              m2 = re.findall('\d+\.\d+%', str(m))
-             line = firstbit + "," + m2[0]
+             line = firstbit + "\t" + m2[0]
 
              # Print out row of csv file
              print(line)

--- a/report_overrepresented_sequences.py
+++ b/report_overrepresented_sequences.py
@@ -33,7 +33,7 @@ def main(argv):
       sys.exit()
 
    # Print out header of csv file
-   header = "\t".join(['Project', 'Library', 'Run', 'Lane', 'Barcode', 'Sequence', 'Percentage'])
+   header = "\t".join(['Project', 'Library', 'Run', 'Lane', 'Barcode', 'Sequence', 'Percent reads trimmed'])
    print(header)
 
    #open the file provenance report

--- a/report_overrepresented_sequences.py
+++ b/report_overrepresented_sequences.py
@@ -2,67 +2,20 @@
 from __future__ import print_function
 
 import sys,getopt,time
-from subprocess import call
+import subprocess
 import csv,zipfile,re
+import os
 
 def usage(long_opts):
    print('report_overrepresented_sequences.py',"[","--"+" --".join(long_opts).replace("="," <val>"),"]")
    print('   use -h to print this message')
 
-def open_fastqc(fastqc_zip,match_string,firstbit):
-    """ 
-    Open the fastqc zip, find the fastqc_data.txt and pull out the matches as specified in match_strings.
-    """
-
-    #open the fastqc zip
-    try:
-        match_string=">>Overrepresented sequences"
-        m=re.match(".*?_(R[1|2])_.*",fastqc_zip)
-        if m is not None:
-            firstbit="\t".join([firstbit, m.group(1)])
-        else:
-            firstbit=firstbit+"\t "
-        with zipfile.ZipFile(fastqc_zip,'r') as myzip:
-            matching = filter(lambda element: "fastqc_data.txt" in element, myzip.namelist())
-            iterator=iter(myzip.read(matching[0],'rU').split("\n"))
-            doathing(iterator,match_string,firstbit)
-    except zipfile.BadZipfile as e:
-        print(" : ".join([time.strftime("%x %X"), "ERROR: BadZipfile", str(e), fastqc_zip]),file=sys.stderr)
-    except IOError as e:
-        print(" : ".join([time.strftime("%x %X"), "ERROR: IOError", str(e), fastqc_zip]),file=sys.stderr)
-
-def doathing(iterator,match_string,firstbit):
-    annotations=False    
-    for line in iterator:
-        if line.startswith(match_string):
-            line = iterator.next()
-            percent=0.0
-            source=[]
-            while not line.startswith(">"):
-                if not line.startswith("#"):
-                    report=line.split("\t")
-                    lineper=float(report[2])
-                    linesou=report[3]
-                    if "Adapter" in linesou:
-                        matstr="(.+?)[,|(]"
-                        m=re.match(matstr,linesou)
-                        if m is not None:
-                            linesou=m.group(1)
-                            percent=percent+lineper
-                            source.append(linesou)
-                line = iterator.next()
-            if source:
-                annotations=True
-                print("\t".join([firstbit, str(percent), ",".join(set(source))]))
-                break
-            #if annotations is not True:
-            #    print(firstbit+"\tN/A")
-
 def main(argv):
    reportarg = []
    test=False
    sw_filename=None
-   long_opts=["test","study-name=","root-sample-name=","sample-name=","sequencer-run-name=","ius-SWID=","lane-SWID=","use-sw-file="]
+   adapter_seq=None
+   long_opts=["use-sw-file=", "adapter-sequence="]
    try:
       opts, args = getopt.getopt(argv,"h",long_opts)
    except getopt.GetoptError:
@@ -74,37 +27,53 @@ def main(argv):
          sys.exit()
       elif opt == '--use-sw-file':
          sw_filename=arg
-      elif opt == '--test':
-         test=True
-      else:
-         reportarg.append(opt)
-	 reportarg.append(arg)
-         title="_".join([title,arg])
+      elif opt == '--adapter-sequence':
+	adapter_seq=arg
 
 
-   if sw_filename is None:
+#   if sw_filename is None:
         #generate the report
-        sw_filename="tmp.tsv"
-        mycall = ["seqware", "files", "report", "--out", sw_filename];
-        mycall.extend(reportarg)
-        call(mycall)
+ #       sw_filename="tmp.tsv"
+  #      mycall = ["seqware", "files", "report", "--out", sw_filename];
+   #     mycall.extend(reportarg)
+    #    call(mycall)
 
 
-   #The strings to match for the FastQC reports
-   #match_strings=["^(Encoding)[\s]*(.*)","^(Total Sequences)[\s]*(.*)","^(Sequence length)[\s]*(.*)","^(%GC)[\s]*(.*)"]
-   match_string="Overrepresented sequences"
+   # Make csv file to write to
+   csvFile = open('AdapterContamination.csv','w')
+   header = ",".join(['Project', 'Library', 'Run', 'Lane', 'Barcode', 'Sequence', 'Percentage'])
+   csvFile.write(header + "\n")
 
    #open the file provenance report
    with open(sw_filename) as tsv:
-      print("\t".join(['Project', 'Library', 'Run', 'Lane', 'Barcode', 'Sequence', 'Count', 'Percentage', 'Possible Source']))
        #parse the report into a map
       for line in csv.DictReader(tsv, delimiter="\t"):
          annos=None
-	 #find the FastQC workflow reports and pull out the annotation lines
-         if line['Workflow Name'] == 'FastQC' and line['File Meta-Type'] == 'application/zip-report-bundle':
-            firstbit="\t".join([ line['Study Title'], line['Sample Name'], line['Sequencer Run Name'], line['Lane Number'], line['IUS Tag'] ])
-            open_fastqc(line['File Path'],match_string,firstbit)
+	 #find the FastQ files and calculates their adapter contamination numbers
+         if 'chemical/seq-na-fastq-gzip' in line['File Meta-Type']:
+             print("in chemical")
+             firstbit=",".join([ line['Study Title'], line['Sample Name'], line['Sequencer Run Name'], line['Lane Number'], line['IUS Tag'] ])
+             # Get Trimmed reads percentage
+             filePath = line['File Path'];
+             m1 = re.match(".*?_(R[1|2])_.*", os.path.basename(filePath))
+             if m1 is not None:
+                 firstbit = ",".join([firstbit, m1.group(1)])
+             else:
+                 firstbit = firstbit + ","
+             p1 = subprocess.Popen(["zcat", filePath], stdout=subprocess.PIPE)
+             p2 = subprocess.Popen(["head", "-100000"], stdin=p1.stdout, stdout=subprocess.PIPE)
+             p1.stdout.close()
+             p3 = subprocess.check_output("cutadapt -a %s -O 10 -o /dev/null -" % (adapter_seq), stderr=subprocess.STDOUT, stdin=p2.stdout, shell=True)
+             p2.stdout.close()
+             m = re.findall('\(\s+\d+\.\d+%\)', p3)
+             m2 = re.findall('\d+\.\d+%', str(m))
 
+             # Write to csv file
+             line = firstbit + "," + m2[0]
+             csvFile.write(line + "\n")
+         else:
+             print("not in chemical")
+   csvFile.close()
 
 if __name__ == "__main__":
    main(sys.argv[1:])

--- a/report_overrepresented_sequences.py
+++ b/report_overrepresented_sequences.py
@@ -1,18 +1,17 @@
-#!/usr/bin/python
+#!/oicr/local/sw/Python-2.7.2/bin/python2.7
 from __future__ import print_function
 
 import sys,getopt,time
 import subprocess
-import csv,zipfile,re
+import csv,re
 import os
+import gzip
 
 def usage(long_opts):
    print('report_overrepresented_sequences.py',"[","--"+" --".join(long_opts).replace("="," <val>"),"]")
    print('   use -h to print this message')
 
 def main(argv):
-   reportarg = []
-   test=False
    sw_filename=None
    adapter_seq=None
    long_opts=["use-sw-file=", "adapter-sequence="]
@@ -29,15 +28,9 @@ def main(argv):
          sw_filename=arg
       elif opt == '--adapter-sequence':
 	adapter_seq=arg
-
-
-#   if sw_filename is None:
-        #generate the report
- #       sw_filename="tmp.tsv"
-  #      mycall = ["seqware", "files", "report", "--out", sw_filename];
-   #     mycall.extend(reportarg)
-    #    call(mycall)
-
+   if adapter_seq is None or sw_filename is None:
+      print("Make sure you give arguments for --use-sw-file and --adapter-sequence.")
+      sys.exit()
 
    # Make csv file to write to
    csvFile = open('AdapterContamination.csv','w')
@@ -45,13 +38,12 @@ def main(argv):
    csvFile.write(header + "\n")
 
    #open the file provenance report
-   with open(sw_filename) as tsv:
+   with gzip.open(sw_filename) as tsv:
        #parse the report into a map
       for line in csv.DictReader(tsv, delimiter="\t"):
          annos=None
 	 #find the FastQ files and calculates their adapter contamination numbers
          if 'chemical/seq-na-fastq-gzip' in line['File Meta-Type']:
-             print("in chemical")
              firstbit=",".join([ line['Study Title'], line['Sample Name'], line['Sequencer Run Name'], line['Lane Number'], line['IUS Tag'] ])
              # Get Trimmed reads percentage
              filePath = line['File Path'];
@@ -63,7 +55,7 @@ def main(argv):
              p1 = subprocess.Popen(["zcat", filePath], stdout=subprocess.PIPE)
              p2 = subprocess.Popen(["head", "-100000"], stdin=p1.stdout, stdout=subprocess.PIPE)
              p1.stdout.close()
-             p3 = subprocess.check_output("cutadapt -a %s -O 10 -o /dev/null -" % (adapter_seq), stderr=subprocess.STDOUT, stdin=p2.stdout, shell=True)
+             p3 = subprocess.check_output("/oicr/local/analysis/sw/cutadapt/cutadapt-0.9.3/cutadapt -a %s -O 10 -o /dev/null -" % (adapter_seq), stderr=subprocess.STDOUT, stdin=p2.stdout, shell=True)
              p2.stdout.close()
              m = re.findall('\(\s+\d+\.\d+%\)', p3)
              m2 = re.findall('\d+\.\d+%', str(m))
@@ -71,8 +63,6 @@ def main(argv):
              # Write to csv file
              line = firstbit + "," + m2[0]
              csvFile.write(line + "\n")
-         else:
-             print("not in chemical")
    csvFile.close()
 
 if __name__ == "__main__":


### PR DESCRIPTION
The report_overrepresented_sequences.py script now will calculate adapter contamination numbers from the fastq files (metatype chemical/seq-na-fastq-gzip) directly using cutadapt.  The hsqwstage-node2.hpc crontab for user hseqwaretest2 has been updated to work with the new scripts, and will produce the same files as the previous version of this script.